### PR TITLE
Fix: Add closed window type

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -10,5 +10,6 @@ export const WILDCARD = '*';
 
 export const WINDOW_TYPE = {
     IFRAME: ('iframe' : 'iframe'),
-    POPUP:  ('popup' : 'popup')
+    POPUP:  ('popup' : 'popup'),
+    CLOSED: ('closed' : 'closed')
 };


### PR DESCRIPTION
Added CLOSED window type to handle scenario when window is closed quickly and prevents an iframe from opening on main page.
https://github.com/paypal/paypal-checkout-components/issues/1339