### PR TITLE
stringifyDomainPattern utility unit tests and bug fixes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -868,7 +868,7 @@ export function matchDomain(pattern : DomainMatcher, origin : DomainMatcher) : b
 
 export function stringifyDomainPattern(pattern : DomainMatcher) : string {
     if (Array.isArray(pattern)) {
-        return `(${ pattern.join(' | ') })`;
+        return `RegExp(${ pattern.join(' | ') })`;
     } else if (isRegex(pattern)) {
         return `RegExp(${ pattern.toString() })`;
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -868,7 +868,7 @@ export function matchDomain(pattern : DomainMatcher, origin : DomainMatcher) : b
 
 export function stringifyDomainPattern(pattern : DomainMatcher) : string {
     if (Array.isArray(pattern)) {
-        return `RegExp(${ pattern.join(' | ') })`;
+        return `(${ pattern.join(' | ') })`;
     } else if (isRegex(pattern)) {
         return `RegExp(${ pattern.toString() })`;
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -870,7 +870,7 @@ export function stringifyDomainPattern(pattern : DomainMatcher) : string {
     if (Array.isArray(pattern)) {
         return `(${ pattern.join(' | ') })`;
     } else if (isRegex(pattern)) {
-        return `RegExp(${ pattern.toString() }`;
+        return `RegExp(${ pattern.toString() })`;
     } else {
         return pattern.toString();
     }

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -9,3 +9,4 @@ import './getOpener';
 import './getParents';
 import './getAllFramesInWindow';
 import './getUserAgent';
+import './stringifyDomainPattern';

--- a/test/tests/stringifyDomainPattern.js
+++ b/test/tests/stringifyDomainPattern.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import { expect } from 'chai';
+
+import { stringifyDomainPattern } from '../../src';
+
+describe('stringifyDomainPattern test cases ', () => {
+
+    it('should stringify a single regex expression', () => {
+
+        const pattern = /[a-zA-Z0-9]{1,5}/;
+        const domainPattern = stringifyDomainPattern(pattern);
+
+        const expected = `RegExp(${ pattern.toString() })`;
+
+        if (typeof domainPattern !== 'string') {
+            throw new TypeError(`Expected domainPattern to be string, instead got ${ typeof domainPattern }`);
+        }
+
+        expect(domainPattern).to.equal(expected);
+
+    });
+    
+});

--- a/test/tests/stringifyDomainPattern.js
+++ b/test/tests/stringifyDomainPattern.js
@@ -6,19 +6,32 @@ import { stringifyDomainPattern } from '../../src';
 
 describe('stringifyDomainPattern test cases ', () => {
 
-    it('should stringify a single regex expression', () => {
+    it('should stringify a single regex expression to RegExp', () => {
 
         const pattern = /[a-zA-Z0-9]{1,5}/;
-        const domainPattern = stringifyDomainPattern(pattern);
+        const domainPatternStringified = stringifyDomainPattern(pattern);
 
         const expected = `RegExp(${ pattern.toString() })`;
 
-        if (typeof domainPattern !== 'string') {
-            throw new TypeError(`Expected domainPattern to be string, instead got ${ typeof domainPattern }`);
+        if (typeof domainPatternStringified !== 'string') {
+            throw new TypeError(`Expected domainPattern to be string, instead got ${ typeof domainPatternStringified }`);
         }
 
-        expect(domainPattern).to.equal(expected);
+        expect(domainPatternStringified).to.equal(expected);
 
+    });
+
+    it('should stringify an array of domain patterns to RegExp', () => {
+
+        const p1 = '/[a-zA-Z0-9]{1,5}/';
+        const p2 = '/\\.[a-zA-Z]{2,}$/';
+        const domainPatternsArray = [ p1, p2 ];
+
+        const domainPatternsArrayStringified = stringifyDomainPattern(domainPatternsArray);
+        
+        const expected = `RegExp(${ p1 } | ${ p2 })`;
+
+        expect(domainPatternsArrayStringified).to.equal(expected);
     });
     
 });

--- a/test/tests/stringifyDomainPattern.js
+++ b/test/tests/stringifyDomainPattern.js
@@ -29,7 +29,7 @@ describe('stringifyDomainPattern test cases ', () => {
 
         const domainPatternsArrayStringified = stringifyDomainPattern(domainPatternsArray);
         
-        const expected = `RegExp(${ p1 } | ${ p2 })`;
+        const expected = `(${ p1 } | ${ p2 })`;
 
         expect(domainPatternsArrayStringified).to.equal(expected);
     });


### PR DESCRIPTION
#12 . Hi, I wrote some tests for the `stringifyDomainPattern` utility and fixed some bugs that my unit tests came across in the function. 
There were 2 minor changes made to the utility function and the reasons for those changes are listed below :

## Change # 1

Initially my `should stringify a single regex expression to RegExp` test was failing with the following error:

<img src="https://i.ibb.co/Zzfq09R/Screenshot-from-2020-10-03-19-20-22.png" alt="Screenshot-from-2020-10-03-19-20-22" border="0" />

I fixed this issue by simply adding a `)` in the return string to `stringifyDomainPattern` function in `src/utils.js ` that seemed to be missing because of a typo which then ran my unit test successfully:

<img src="https://i.ibb.co/ChwvNfD/Screenshot-from-2020-10-03-19-25-28.png" alt="Screenshot-from-2020-10-03-19-25-28" border="0" />

## Change # 2

I noticed that the function also accepts array of regex patterns but the return was without `RegExp` but still had parentheses which indicated that the `RegExp` function missing was a mistake. It also made for inconsistant string returns. This then caused my test `should stringify an array of domain patterns to RegExp` to break with the folowing output: 

<img src="https://i.ibb.co/NxWLfSw/Screenshot-from-2020-10-03-21-36-58.png" alt="Screenshot-from-2020-10-03-21-36-58" border="0">

I simply added `RegExp` to the return string and that change made my test succeed

<img src="https://i.ibb.co/jTJC9RX/Screenshot-from-2020-10-03-21-38-32.png" alt="Screenshot-from-2020-10-03-21-38-32" border="0">

Please let me know if anything needs to be reverted or if there is something else you'd like me to do to meet the merge requirements.